### PR TITLE
Filtrar diarios por fecha actual

### DIFF
--- a/importar_diarios_helpdesk.py
+++ b/importar_diarios_helpdesk.py
@@ -168,12 +168,19 @@ def get_timesheet_ticket_field(
 
 
 def fetch_diarios(
-    cursor: pyodbc.Cursor, limit: Optional[int] = None
+    cursor: pyodbc.Cursor,
+    limit: Optional[int] = None,
+    target_date: Optional[dt.date] = None,
 ) -> List[Dict[str, object]]:
-    """Leer la vista ``V_MV_Diarios`` y devolver los registros como diccionarios."""
+    """Leer la vista ``V_MV_Diarios`` filtrando por la fecha indicada."""
 
-    query = "SELECT * FROM V_MV_Diarios"
-    cursor.execute(query)
+    if target_date is None:
+        target_date = dt.date.today()
+
+    logger.info("Filtrando diarios por fecha: %s", target_date.isoformat())
+
+    query = "SELECT * FROM V_MV_Diarios WHERE CAST(FECHAINICIO AS DATE) = ?"
+    cursor.execute(query, target_date)
     rows = cursor.fetchmany(limit) if limit else cursor.fetchall()
     columns = [column[0] for column in cursor.description]
     data = [dict(zip(columns, row)) for row in rows]


### PR DESCRIPTION
## Summary
- limitar la lectura de V_MV_Diarios a los registros de la fecha actual utilizando CAST(FECHAINICIO AS DATE)
- registrar en el log la fecha utilizada para el filtro diario

## Testing
- python -m compileall importar_diarios_helpdesk.py

------
https://chatgpt.com/codex/tasks/task_e_68cc679b998c832cbc80e4e472ad5c8a